### PR TITLE
build: Properly enable Doxygen warnings.

### DIFF
--- a/project/bb/libll/Jamfile
+++ b/project/bb/libll/Jamfile
@@ -66,7 +66,7 @@ doxygen api.html
     <doxygen:param>STRIP_FROM_PATH="\"$(root)/src\""
     <doxygen:param>STRIP_FROM_INC_PATH="\"$(root)/src\""
 
-    <doxygen:param>EXTRACT_ALL=YES
+    <doxygen:param>EXTRACT_ALL=NO
     <doxygen:param>EXTRACT_PRIVATE=YES
     <doxygen:param>EXTRACT_PACKAGE=YES
     <doxygen:param>EXTRACT_STATIC=YES

--- a/project/bb/libtl/Jamfile
+++ b/project/bb/libtl/Jamfile
@@ -65,7 +65,7 @@ doxygen api.html
     <doxygen:param>STRIP_FROM_PATH="\"$(root)/src\""
     <doxygen:param>STRIP_FROM_INC_PATH="\"$(root)/src\""
 
-    <doxygen:param>EXTRACT_ALL=YES
+    <doxygen:param>EXTRACT_ALL=NO
     <doxygen:param>EXTRACT_PRIVATE=YES
     <doxygen:param>EXTRACT_PACKAGE=YES
     <doxygen:param>EXTRACT_STATIC=YES


### PR DESCRIPTION
This will generate lots of warnings.